### PR TITLE
Keycloak refresh token is simplier in 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # aerogear-ios-oauth2 [![Build Status](https://travis-ci.org/aerogear/aerogear-ios-oauth2.png)](https://travis-ci.org/aerogear/aerogear-ios-oauth2)
+
+> **NOTE:**  The library has been tested with Xcode 6.1.1
+
 OAuth2 Client based on [aerogear-ios-http](https://github.com/aerogear/aerogear-ios-http). 
 Taking care of: 
 
@@ -12,8 +15,6 @@ Taking care of:
 * openID Connect login
 
 100% Swift.
-
-> **NOTE:**  The library has been tested with Xcode 6.1.1
 
 |                 | Project Info  |
 | --------------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ Taking care of:
 * (implicit or explicit) refresh tokens, 
 * revoke tokens,
 * permanent secure storage,
-* adaptable to OAuth2 specific providers. Existing extensions: Google, Facebook, Keycloak etc...
+* adaptable to OAuth2 specific providers. Existing extensions: Google, Facebook, [Keycloak 1.1.0.Final](http://keycloak.jboss.org/) etc...
 * openID Connect login
 
 100% Swift.
+
+> **NOTE:**  The library has been tested with Xcode 6.1.1
 
 |                 | Project Info  |
 | --------------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Inject OAuth2Module into http object in [4] and uses the http object to GET/POST
 
 See full description in [aerogear.org](https://aerogear.org/docs/guides/aerogear-ios-2.X/Authorization/)
 
-#### OpenID Connect 
+#### OpenID Connect with Keycloak
 ```swift
 var Http = Http()
 let keycloakConfig = KeycloakConfig(
@@ -68,7 +68,9 @@ oauth2Module.login {(accessToken: AnyObject?, claims: OpenIDClaim?, error: NSErr
 ```
 Similar approach for configuration, here we want to login as Keycloak user, using ```login``` method we get some user information back in OpenIDClaim object.
 
-### Build, test and play with aerogear-ios-jsonsz
+> **NOTE:**  The latest version of the library works with Keycloak 1.1.0.Final. Previous version of Keycloak 1.0.x will work except for the transparent refresh of tokens (ie: after access token expires you will have to go through grant process).
+
+### Build, test and play with aerogear-ios-oauth2
 
 1. Clone this project
 


### PR DESCRIPTION
To test:
on 'shoot-realm' (https://github.com/aerogear/aerogear-backend-cookbook/blob/master/Shoot/configuration/shoot-realm.json#L3) add:
    "accessTokenLifespan": 30,
    "ssoSessionIdleTimeout": 120,
to shorten default value: exp time for access token 30s and refresh token exp time: 2mins

1. upload a photo to KC for first time (do authz flow)
2. wait 30s (but before 2mins), upload a photo, the token is refreshed transparently without prompting the user
3. wait 2 mins, upload a photo, the user is prompted to go to authz flow again

Note: this PR required KC1.1

@abstractj @cvasilak mind to review?