### PR TITLE
Update Google token endpoints

### DIFF
--- a/AeroGearOAuth2/AccountManager.swift
+++ b/AeroGearOAuth2/AccountManager.swift
@@ -65,12 +65,12 @@ public class GoogleConfig: Config {
     public init(clientId: String, scopes: [String], accountId: String? = nil, isOpenIDConnect: Bool = false) {
         let bundleString = NSBundle.mainBundle().bundleIdentifier ?? "google"
         super.init(base: "https://accounts.google.com",
-            authzEndpoint: "o/oauth2/auth",
+            authzEndpoint: "o/oauth2/v2/auth",
             redirectURL: "\(bundleString):/oauth2Callback",
             accessTokenEndpoint: "o/oauth2/token",
             clientId: clientId,
             refreshTokenEndpoint: "o/oauth2/token",
-            revokeTokenEndpoint: "rest/revoke",
+            revokeTokenEndpoint: "o/oauth2/revoke",
             isOpenIDConnect: isOpenIDConnect,
             userInfoEndpoint: isOpenIDConnect ? "https://www.googleapis.com/plus/v1/people/me/openIdConnect" : nil,
             scopes: scopes,
@@ -117,11 +117,11 @@ An account manager used to instantiate, store and retrieve OAuth2 modules.
 public class AccountManager {
     /// List of OAuth2 modules available for a given app. Each module is linked to an OAuht2Session which securely store the tokens.
     var modules: [String: OAuth2Module]
-    
+
     init() {
         self.modules = [String: OAuth2Module]()
     }
-    
+
     /// access a shared instance of an account manager
     public class var sharedInstance: AccountManager {
         struct Singleton {
@@ -129,13 +129,13 @@ public class AccountManager {
         }
         return Singleton.instance
     }
-    
+
     /**
     Instantiate an OAuth2 Module using the configuration object passed in and adds it to the account manager. It uses the OAuth2Session account_id as the name that this module will be stored in.
-    
+
     :param: config  the configuration object to use to setup an OAuth2 module.
     :param: moduleClass the type of the OAuth2 module to instantiate.
-    
+
     :returns: the OAuth2 module
     */
     public class func addAccount(config: Config, moduleClass: OAuth2Module.Type) -> OAuth2Module {
@@ -145,36 +145,36 @@ public class AccountManager {
         sharedInstance.modules[myModule.oauth2Session.accountId] = myModule
         return myModule
     }
-    
+
     /**
     Removes an OAuth2 module
-    
+
     :param: name  the name that the OAuth2 module was bound to.
     :param: config the configuration object to use to setup an OAuth2 module.
     :param: moduleClass the type of the OAuth2 module to instantiate.
-    
+
     :returns: the OAuth2module or nil if not found
     */
     public class func removeAccount(name: String, config: Config, moduleClass: OAuth2Module.Type) -> OAuth2Module? {
         return sharedInstance.modules.removeValueForKey(name)
     }
-    
+
     /**
     Retrieves an OAuth2 module by a name
-    
+
     :param: name the name that the OAuth2 module was bound to.
-    
+
     :returns: the OAuth2module or nil if not found.
     */
     public class func getAccountByName(name: String) -> OAuth2Module? {
         return sharedInstance.modules[name]
     }
-    
+
     /**
     Retrieves a list of OAuth2 modules bound to specific clientId.
-    
+
     :param: clientId  the client it that the oauth2 module was bound to.
-    
+
     :returns: the OAuth2module or nil if not found.
     */
     public class func getAccountsByClienId(clientId: String) -> [OAuth2Module] {
@@ -182,12 +182,12 @@ public class AccountManager {
         return modules.filter {$0.config.clientId == clientId }
     }
 
-    
+
     /**
     Retrieves an OAuth2 module by using a configuration object.
-    
+
     :param: config the Config object that this oauth2 module was used to instantiate.
-    
+
     :returns: the OAuth2module or nil if not found.
     */
     public class func getAccountByConfig(config: Config) -> OAuth2Module? {
@@ -205,31 +205,31 @@ public class AccountManager {
 
     /**
     Convenient method to retrieve a Facebook oauth2 module.
-    
+
     :param: config a Facebook configuration object. See FacebookConfig.
-    
+
     :returns: a Facebook OAuth2 module.
     */
     public class func addFacebookAccount(config: FacebookConfig) -> FacebookOAuth2Module {
         return addAccount(config, moduleClass: FacebookOAuth2Module.self) as! FacebookOAuth2Module
     }
-    
+
     /**
     Convenient method to retrieve a Google oauth2 module ready to be used.
-    
+
     :param: config a google configuration object. See GoogleConfig.
-    
+
     :returns: a google OAuth2 module.
     */
     public class func addGoogleAccount(config: GoogleConfig) -> OAuth2Module {
         return addAccount(config, moduleClass: OAuth2Module.self)
     }
-    
+
     /**
     Convenient method to retrieve a Keycloak oauth2 module ready to be used.
-    
+
     :param: config a Keycloak configuration object. See KeycloakConfig.
-    
+
     :returns: a Keycloak OAuth2 module.
     */
     public class func addKeycloakAccount(config: KeycloakConfig) -> KeycloakOAuth2Module {


### PR DESCRIPTION
This is a minor change. The proper Google token endpoint is actually `https://www.googleapis.com/oauth2/v4/token` but with the way Config is setup to use the base url, this can't currently be updated.