### PR TITLE
Fix TrustedPersistantOAuth2Session init

### DIFF
--- a/AeroGearOAuth2/TrustedPersistantOAuth2Session.swift
+++ b/AeroGearOAuth2/TrustedPersistantOAuth2Session.swift
@@ -362,11 +362,11 @@ public class TrustedPersistantOAuth2Session: OAuth2Session {
                 self.refreshToken = refreshToken
             }
 
-            if accessTokenExpirationDate != nil {
+            if accessToken != nil && accessTokenExpirationDate != nil {
                 self.accessTokenExpirationDate = accessTokenExpirationDate
             }
 
-            if refreshToken != nil {
+            if refreshToken != nil && refreshTokenExpirationDate != nil {
                 self.refreshTokenExpirationDate = refreshTokenExpirationDate
             }
     }


### PR DESCRIPTION
Fixes a bug in the init of TrustedPersistantOAuth2Session where refreshTokenExpirationDate was deleted from Keychain when the refreshToken wasn't nil.
