### PR TITLE
Add ID token to token response

### DIFF
--- a/AeroGearOAuth2/FacebookOAuth2Module.swift
+++ b/AeroGearOAuth2/FacebookOAuth2Module.swift
@@ -64,7 +64,7 @@ open class FacebookOAuth2Module: OAuth2Module {
                         expiredIn = array[index+1]
                     }
                 }
-                self.oauth2Session.save(accessToken: accessToken, refreshToken: nil, accessTokenExpiration: expiredIn, refreshTokenExpiration: nil)
+                self.oauth2Session.save(accessToken: accessToken, refreshToken: nil, accessTokenExpiration: expiredIn, refreshTokenExpiration: nil, idToken: nil)
                 completionHandler(accessToken as AnyObject?, nil)
             }
         })

--- a/AeroGearOAuth2/KeycloakOAuth2Module.swift
+++ b/AeroGearOAuth2/KeycloakOAuth2Module.swift
@@ -90,7 +90,7 @@ open class KeycloakOAuth2Module: OAuth2Module {
                     let expRefresh = expirationRefresh?.stringValue
 
                     // in Keycloak refresh token get refreshed every time you use them
-                    self.oauth2Session.save(accessToken: accessToken, refreshToken: refreshToken, accessTokenExpiration: exp, refreshTokenExpiration: expRefresh)
+                    self.oauth2Session.save(accessToken: accessToken, refreshToken: refreshToken, accessTokenExpiration: exp, refreshTokenExpiration: expRefresh, idToken: nil)
                     completionHandler(accessToken as AnyObject?, nil)
                 }
             })

--- a/AeroGearOAuth2/OAuth2Module.swift
+++ b/AeroGearOAuth2/OAuth2Module.swift
@@ -56,6 +56,7 @@ open class OAuth2Module: AuthzModule {
     var applicationDidBecomeActiveNotificationObserver: NSObjectProtocol?
     var state: AuthorizationState
     open var webView: OAuth2WebViewController?
+    open var idToken: String?
 
     /**
     Initialize an OAuth2 module.
@@ -164,7 +165,7 @@ open class OAuth2Module: AuthzModule {
                         refreshToken = newRefreshToken
                     }
 
-                    self.oauth2Session.save(accessToken: accessToken, refreshToken: refreshToken, accessTokenExpiration: exp, refreshTokenExpiration: nil)
+                    self.oauth2Session.save(accessToken: accessToken, refreshToken: refreshToken, accessTokenExpiration: exp, refreshTokenExpiration: nil, idToken: nil)
 
                     completionHandler(unwrappedResponse["access_token"], nil)
                 }
@@ -199,15 +200,17 @@ open class OAuth2Module: AuthzModule {
     }
 
     open func tokenResponse(_ unwrappedResponse: [String: AnyObject]) -> String {
-        let accessToken: String = unwrappedResponse["access_token"] as! String
+        let accessToken: String   = unwrappedResponse["access_token"] as! String
         let refreshToken: String? = unwrappedResponse["refresh_token"] as? String
-        let expiration = unwrappedResponse["expires_in"] as? NSNumber
-        let exp: String? = expiration?.stringValue
+        let idToken: String?      = unwrappedResponse["id_token"] as? String
+        let expiration            = unwrappedResponse["expires_in"] as? NSNumber
+        let exp: String?          = expiration?.stringValue
         // expiration for refresh token is used in Keycloak
-        let expirationRefresh = unwrappedResponse["refresh_expires_in"] as? NSNumber
-        let expRefresh = expirationRefresh?.stringValue
+        let expirationRefresh     = unwrappedResponse["refresh_expires_in"] as? NSNumber
+        let expRefresh            = expirationRefresh?.stringValue
 
-        self.oauth2Session.save(accessToken: accessToken, refreshToken: refreshToken, accessTokenExpiration: exp, refreshTokenExpiration: expRefresh)
+        self.oauth2Session.save(accessToken: accessToken, refreshToken: refreshToken, accessTokenExpiration: exp, refreshTokenExpiration: expRefresh, idToken: idToken)
+        self.idToken    = self.oauth2Session.idToken
 
         return accessToken
     }

--- a/AeroGearOAuth2/OAuth2Session.swift
+++ b/AeroGearOAuth2/OAuth2Session.swift
@@ -47,6 +47,11 @@ public protocol OAuth2Session {
     var refreshToken: String? {get set}
 
     /**
+    The JWT which expires.
+    */
+    var idToken: String? {get set}
+
+    /**
     Check validity of accessToken. return true if still valid, false when expired.
     */
     func tokenIsNotExpired() -> Bool
@@ -71,5 +76,5 @@ public protocol OAuth2Session {
     :param: accessTokenExpiration the expiration for the access token.
     :param: refreshTokenExpiration the expiration for the refresh token.
     */
-    func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?)
+    func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?, idToken: String?)
 }

--- a/AeroGearOAuth2/TrustedPersistantOAuth2Session.swift
+++ b/AeroGearOAuth2/TrustedPersistantOAuth2Session.swift
@@ -32,6 +32,7 @@ public enum TokenType: String {
     case RefreshToken = "RefreshToken"
     case ExpirationDate = "ExpirationDate"
     case RefreshExpirationDate = "RefreshExpirationDate"
+    case IdToken = "IdToken"
 }
 
 /**
@@ -285,6 +286,20 @@ public class TrustedPersistantOAuth2Session: OAuth2Session {
         }
     }
 
+    /**
+    The JWT. The information is read securely from Keychain.
+    */
+    public var idToken: String? {
+        get {
+            return self.keychain.read(userAccount: self.accountId, tokenType: .IdToken)
+        }
+        set(value) {
+            if let unwrappedValue = value {
+                _ = self.keychain.save(key: self.accountId, tokenType: .IdToken, value: unwrappedValue)
+            }
+        }
+    }
+
     private let keychain: KeychainWrap
 
     /**
@@ -304,9 +319,10 @@ public class TrustedPersistantOAuth2Session: OAuth2Session {
     /**
     Save in memory tokens information. Saving tokens allow you to refresh accesstoken transparently for the user without prompting for grant access.
     */
-    public func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?) {
+    public func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?, idToken: String?) {
         self.accessToken = accessToken
         self.refreshToken = refreshToken
+        self.idToken = idToken
 
         let now = Date()
         if let inter = accessTokenExpiration?.doubleValue {
@@ -325,6 +341,7 @@ public class TrustedPersistantOAuth2Session: OAuth2Session {
         self.refreshToken = nil
         self.accessTokenExpirationDate = nil
         self.refreshTokenExpirationDate = nil
+        self.idToken = nil
     }
 
     /**

--- a/AeroGearOAuth2/UntrustedMemoryOAuth2Session.swift
+++ b/AeroGearOAuth2/UntrustedMemoryOAuth2Session.swift
@@ -53,6 +53,11 @@ open class UntrustedMemoryOAuth2Session: OAuth2Session {
     open var refreshTokenExpirationDate: Date?
 
     /**
+    The JWT which expires.
+    */
+    open var idToken: String?
+
+    /**
     Check validity of accessToken. return true if still valid, false when expired.
     */
     open func tokenIsNotExpired() -> Bool {
@@ -69,7 +74,7 @@ open class UntrustedMemoryOAuth2Session: OAuth2Session {
     /**
     Save in memory tokens information. Saving tokens allow you to refresh accesstoken transparently for the user without prompting for grant access.
     */
-    open func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?) {
+    open func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?, idToken: String?) {
         self.accessToken = accessToken
         self.refreshToken = refreshToken
         let now = Date()

--- a/AeroGearOAuth2Tests/OAuth2ModuleMock.swift
+++ b/AeroGearOAuth2Tests/OAuth2ModuleMock.swift
@@ -33,6 +33,7 @@ open class MockOAuth2SessionWithValidAccessTokenStored: OAuth2Session {
     open var accessTokenExpirationDate: Date?
     open var refreshTokenExpirationDate: Date?
     open var refreshToken: String?
+    open var idToken: String?
     open func tokenIsNotExpired() -> Bool {
         return true
     }
@@ -42,7 +43,7 @@ open class MockOAuth2SessionWithValidAccessTokenStored: OAuth2Session {
     }
 
     open func clearTokens() {}
-    open func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?) {}
+    open func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?, idToken: String?) {}
     public init() {}
 }
 
@@ -71,7 +72,7 @@ open class MockOAuth2SessionWithRefreshToken: MockOAuth2SessionWithValidAccessTo
     open override func tokenIsNotExpired() -> Bool {
         return false
     }
-    open override func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?) {
+    open override func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?, idToken: String?) {
         savedRefreshedToken = refreshToken
     }
     open override func clearTokens() {initCalled = 1}


### PR DESCRIPTION
Many services such as OpenID Connect use an ID token/JWT to transmit data about a user back to the client once the user has authenticated with an OAuth2 service. This commit allows that JWT to be stored in the keychain and passed to the client.