### PR TITLE
Add audience field and server code to OAuth2Module

### DIFF
--- a/AeroGearOAuth2/AccountManager.swift
+++ b/AeroGearOAuth2/AccountManager.swift
@@ -62,19 +62,22 @@ open class GoogleConfig: Config {
     :param: accountId this unique id is used by AccountManager to identify the OAuth2 client.
     :paream: isOpenIDConnect to identify if fetching id information is required.
     */
-    public init(clientId: String, scopes: [String], accountId: String? = nil, isOpenIDConnect: Bool = false) {
+    public init(clientId: String, scopes: [String], audienceId: String? = nil, accountId: String? = nil, isOpenIDConnect: Bool = false) {
         let bundleString = Bundle.main.bundleIdentifier ?? "google"
         super.init(base: "https://accounts.google.com",
             authzEndpoint: "o/oauth2/v2/auth",
             redirectURL: "\(bundleString):/oauth2Callback",
             accessTokenEndpoint: "o/oauth2/token",
             clientId: clientId,
+            audienceId: audienceId,
             refreshTokenEndpoint: "o/oauth2/token",
             revokeTokenEndpoint: "o/oauth2/revoke",
             isOpenIDConnect: isOpenIDConnect,
             userInfoEndpoint: isOpenIDConnect ? "https://www.googleapis.com/plus/v1/people/me/openIdConnect" : nil,
             scopes: scopes,
-            accountId: accountId)
+            accountId: accountId
+        )
+
         // Add openIdConnect scope
         if self.isOpenIDConnect {
             self.scopes += ["openid", "email", "profile"]
@@ -96,14 +99,16 @@ open class KeycloakConfig: Config {
         let bundleString = Bundle.main.bundleIdentifier ?? "keycloak"
         let defaulRealmName = String(format: "%@-realm", clientId)
         let realm = realm ?? defaulRealmName
-        super.init(base: "\(host)/auth",
+        super.init(
+            base: "\(host)/auth",
             authzEndpoint: "realms/\(realm)/protocol/openid-connect/auth",
             redirectURL: "\(bundleString)://oauth2Callback",
             accessTokenEndpoint: "realms/\(realm)/protocol/openid-connect/token",
             clientId: clientId,
             refreshTokenEndpoint: "realms/\(realm)/protocol/openid-connect/token",
             revokeTokenEndpoint: "realms/\(realm)/protocol/openid-connect/logout",
-            isOpenIDConnect: isOpenIDConnect)
+            isOpenIDConnect: isOpenIDConnect
+        )
         // Add openIdConnect scope
         if self.isOpenIDConnect {
             self.scopes += ["openid", "email", "profile"]

--- a/AeroGearOAuth2/Config.swift
+++ b/AeroGearOAuth2/Config.swift
@@ -92,6 +92,11 @@ open class Config {
     open let clientSecret: String?
 
     /**
+    Applies the "audience" obtained with the client registration process.
+    */
+    public let audienceId: String?
+
+    /**
     Account id is used with AccountManager to store tokens. AccountId is defined by the end-user
     and can be any String. If AccountManager is not used, this field is optional.
     */
@@ -111,7 +116,7 @@ open class Config {
         UIApplication.shared.keyWindow?.rootViewController?.present(webView, animated: true, completion: nil)
     }
 
-    public init(base: String, authzEndpoint: String, redirectURL: String, accessTokenEndpoint: String, clientId: String, refreshTokenEndpoint: String? = nil, revokeTokenEndpoint: String? = nil, isOpenIDConnect: Bool = false, userInfoEndpoint: String? = nil, scopes: [String] = [],  clientSecret: String? = nil, accountId: String? = nil, isWebView: Bool = false) {
+    public init(base: String, authzEndpoint: String, redirectURL: String, accessTokenEndpoint: String, clientId: String, audienceId: String? = nil, refreshTokenEndpoint: String? = nil, revokeTokenEndpoint: String? = nil, isOpenIDConnect: Bool = false, userInfoEndpoint: String? = nil, scopes: [String] = [],  clientSecret: String? = nil, accountId: String? = nil, isWebView: Bool = false) {
         self.baseURL = base
         self.authzEndpoint = authzEndpoint
         self.redirectURL = redirectURL
@@ -123,6 +128,7 @@ open class Config {
         self.scopes = scopes
         self.clientId = clientId
         self.clientSecret = clientSecret
+        self.audienceId = audienceId
         self.accountId = accountId
         self.isWebView = isWebView
     }

--- a/AeroGearOAuth2/OAuth2Module.swift
+++ b/AeroGearOAuth2/OAuth2Module.swift
@@ -57,6 +57,7 @@ open class OAuth2Module: AuthzModule {
     var state: AuthorizationState
     open var webView: OAuth2WebViewController?
     open var idToken: String?
+    open var serverCode: String?
 
     /**
     Initialize an OAuth2 module.
@@ -122,13 +123,18 @@ open class OAuth2Module: AuthzModule {
         self.state = .authorizationStatePendingExternalApproval
 
         // calculate final url
-        let params = "?scope=\(config.scope)&redirect_uri=\(config.redirectURL.urlEncode())&client_id=\(config.clientId)&response_type=code"
-        guard let computedUrl = http.calculateURL(baseURL: config.baseURL, url:config.authzEndpoint) else {
+        var params = "?scope=\(config.scope)&redirect_uri=\(config.redirectURL.urlEncode())&client_id=\(config.clientId)&response_type=code"
+
+        if let audienceId = config.audienceId {
+            params = "\(params)&audience=\(audienceId)"
+        }
+
+        guard let computedUrl = http.calculateURL(baseURL: config.baseURL, url: config.authzEndpoint) else {
             let error = NSError(domain:AGAuthzErrorDomain, code:0, userInfo:["NSLocalizedDescriptionKey": "Malformatted URL."])
             completionHandler(nil, error)
             return
         }
-        if let url = URL(string:computedUrl.absoluteString + params) {
+        if let url = URL(string: computedUrl.absoluteString + params) {
             if self.webView != nil {
                 self.webView!.targetURL = url
                 config.webViewHandler(self.webView!, completionHandler)
@@ -186,6 +192,10 @@ open class OAuth2Module: AuthzModule {
             paramDict["client_secret"] = unwrapped
         }
 
+        if let audience = config.audienceId {
+            paramDict["audience"] = audience
+        }
+
         http.request(method: .post, path: config.accessTokenEndpoint, parameters: paramDict as [String : AnyObject]?, completionHandler: {(responseObject, error) in
             if (error != nil) {
                 completionHandler(nil, error)
@@ -203,6 +213,7 @@ open class OAuth2Module: AuthzModule {
         let accessToken: String   = unwrappedResponse["access_token"] as! String
         let refreshToken: String? = unwrappedResponse["refresh_token"] as? String
         let idToken: String?      = unwrappedResponse["id_token"] as? String
+        let serverCode: String?   = unwrappedResponse["server_code"] as? String
         let expiration            = unwrappedResponse["expires_in"] as? NSNumber
         let exp: String?          = expiration?.stringValue
         // expiration for refresh token is used in Keycloak
@@ -211,6 +222,7 @@ open class OAuth2Module: AuthzModule {
 
         self.oauth2Session.save(accessToken: accessToken, refreshToken: refreshToken, accessTokenExpiration: exp, refreshTokenExpiration: expRefresh, idToken: idToken)
         self.idToken    = self.oauth2Session.idToken
+        self.serverCode = serverCode
 
         return accessToken
     }

--- a/AeroGearOAuth2Tests/OAuth2ModuleMock.swift
+++ b/AeroGearOAuth2Tests/OAuth2ModuleMock.swift
@@ -34,6 +34,7 @@ open class MockOAuth2SessionWithValidAccessTokenStored: OAuth2Session {
     open var refreshTokenExpirationDate: Date?
     open var refreshToken: String?
     open var idToken: String?
+    open var serverCode: String?
     open func tokenIsNotExpired() -> Bool {
         return true
     }

--- a/AeroGearOAuth2Tests/OAuth2ModuleTest.swift
+++ b/AeroGearOAuth2Tests/OAuth2ModuleTest.swift
@@ -17,7 +17,7 @@
 
 import UIKit
 import XCTest
-import AeroGearOAuth2
+@testable import AeroGearOAuth2
 import AeroGearHttp
 import OHHTTPStubs
 
@@ -180,5 +180,23 @@ class OAuth2ModuleTests: XCTestCase {
             expectation.fulfill()
         })
         waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testGoogleURLParams() {
+        let googleConfig = GoogleConfig(
+            clientId: "xxx.apps.googleusercontent.com",
+            scopes:["https://www.googleapis.com/auth/drive"],
+            audienceId: "xxx2.apps.googleusercontent.com"
+        )
+        googleConfig.isWebView = true
+
+        let mockedSession = MockOAuth2SessionWithRefreshToken()
+        let oauth2Module = OAuth2Module(config: googleConfig, session: mockedSession)
+        oauth2Module.requestAuthorizationCode { (response: AnyObject?, error:NSError?) -> Void in
+            // noop
+        }
+
+        let urlString = oauth2Module.webView!.targetURL.absoluteString
+        XCTAssertNotNil(urlString.range(of: "audience"), "If URL string doesn't contain an audience field")
     }
 }


### PR DESCRIPTION
This commit allows developers to do two things:

* Ensure that the app making the OAuth2 request is the intended recipient of the
access token (see here for more: https://oauth.net/articles/authentication/) by
validating the audience field against the client ID

* Allow developers to do cross-client authorization, where both a client and backend
server can make separate authorized requests to a service without each needing
to be authorized by the user. See more info here:
https://developers.google.com/identity/protocols/CrossClientAuth and here:
https://developers.google.com/identity/sign-in/ios/offline-access