### PR TITLE
AGIOS-531: Allow use of SFSafariViewController

### DIFF
--- a/AeroGearOAuth2/Config.swift
+++ b/AeroGearOAuth2/Config.swift
@@ -98,10 +98,21 @@ open class Config {
     open var accountId: String?
 
     /**
+    Enum to denote what kind of webView to use.
+    */
+    public enum WebViewType {
+        case embeddedWebView
+        case externalSafari
+        // SFSafariViewController only available in iOS 9+
+        @available(iOS 9.0, *)
+        case safariViewController
+    }
+    
+    /**
     Boolean to indicate to either used a webview (if true) or an external browser (by default, false)
     for authorization code grant flow.
     */
-    open var isWebView: Bool = false
+    open var webView: WebViewType = WebViewType.externalSafari
 
     /**
     A handler to allow the webview to be pushed onto the navigation controller
@@ -111,7 +122,7 @@ open class Config {
         UIApplication.shared.keyWindow?.rootViewController?.present(webView, animated: true, completion: nil)
     }
 
-    public init(base: String, authzEndpoint: String, redirectURL: String, accessTokenEndpoint: String, clientId: String, refreshTokenEndpoint: String? = nil, revokeTokenEndpoint: String? = nil, isOpenIDConnect: Bool = false, userInfoEndpoint: String? = nil, scopes: [String] = [],  clientSecret: String? = nil, accountId: String? = nil, isWebView: Bool = false) {
+    public init(base: String, authzEndpoint: String, redirectURL: String, accessTokenEndpoint: String, clientId: String, refreshTokenEndpoint: String? = nil, revokeTokenEndpoint: String? = nil, isOpenIDConnect: Bool = false, userInfoEndpoint: String? = nil, scopes: [String] = [],  clientSecret: String? = nil, accountId: String? = nil, webView: WebViewType = WebViewType.externalSafari) {
         self.baseURL = base
         self.authzEndpoint = authzEndpoint
         self.redirectURL = redirectURL
@@ -124,6 +135,6 @@ open class Config {
         self.clientId = clientId
         self.clientSecret = clientSecret
         self.accountId = accountId
-        self.isWebView = isWebView
+        self.webView = webView
     }
 }

--- a/AeroGearOAuth2/Config.swift
+++ b/AeroGearOAuth2/Config.swift
@@ -106,7 +106,7 @@ open class Config {
     /**
     A handler to allow the webview to be pushed onto the navigation controller
     */
-    open var webViewHandler: ((OAuth2WebViewController, _ completionHandler: (AnyObject?, NSError?) -> Void) -> ()) = {
+    open var webViewHandler: ((UIViewController, _ completionHandler: (AnyObject?, NSError?) -> Void) -> ()) = {
         (webView, completionHandler) in
         UIApplication.shared.keyWindow?.rootViewController?.present(webView, animated: true, completion: nil)
     }

--- a/AeroGearOAuth2/OAuth2Module.swift
+++ b/AeroGearOAuth2/OAuth2Module.swift
@@ -80,7 +80,7 @@ open class OAuth2Module: AuthzModule {
         }
 
         self.config = config
-        if config.isWebView {
+        if config.webView == .embeddedWebView {
             self.webView = OAuth2WebViewController()
         }
         self.http = Http(baseURL: config.baseURL, requestSerializer: requestSerializer, responseSerializer:  responseSerializer)
@@ -130,15 +130,18 @@ open class OAuth2Module: AuthzModule {
             return
         }
         if let url = URL(string:computedUrl.absoluteString + params) {
-            if self.webView != nil {
-                self.webView!.targetURL = url
-                config.webViewHandler(self.webView!, completionHandler)
-            } else {
+            switch config.webView {
+            case .embeddedWebView:
+                if self.webView != nil {
+                    self.webView!.targetURL = url
+                    config.webViewHandler(self.webView!, completionHandler)
+                }
+            case .externalSafari:
+                UIApplication.shared.openURL(url)
+            case .safariViewController:
                 if #available(iOS 9.0, *) {
                     let safariController = SFSafariViewController(url: url)
                     config.webViewHandler(safariController, completionHandler)
-                } else {
-                    UIApplication.shared.openURL(url)
                 }
             }
         }

--- a/AeroGearOAuth2/OAuth2Module.swift
+++ b/AeroGearOAuth2/OAuth2Module.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import UIKit
+import SafariServices
 import AeroGearHttp
 
 /**
@@ -133,7 +134,12 @@ open class OAuth2Module: AuthzModule {
                 self.webView!.targetURL = url
                 config.webViewHandler(self.webView!, completionHandler)
             } else {
-                UIApplication.shared.openURL(url)
+                if #available(iOS 9.0, *) {
+                    let safariController = SFSafariViewController(url: url)
+                    config.webViewHandler(safariController, completionHandler)
+                } else {
+                    UIApplication.shared.openURL(url)
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds support for use of `SFSafariViewController` to make a better UX for developers who choose to use the external browser rather than embedded webview.