### PR TITLE
Fix spelling errors

### DIFF
--- a/AeroGearOAuth2/AccountManager.swift
+++ b/AeroGearOAuth2/AccountManager.swift
@@ -18,7 +18,7 @@
 import Foundation
 
 /**
-A Config object that setups facebook specific configuration parameters.
+A Config object that setups Facebook specific configuration parameters.
 */
 open class FacebookConfig: Config {
     /**
@@ -27,7 +27,7 @@ open class FacebookConfig: Config {
     :param: clientSecret OAuth2 credentials an unique string that is generated in the OAuth2 provider Developers Console.
     :param: scopes an array of scopes the app is asking access to.
     :param: accountId this unique id is used by AccountManager to identify the OAuth2 client.
-    :paream: isOpenIDConnect to identify if fetching id information is required.
+    :param: isOpenIDConnect to identify if fetching id information is required.
     */
     public init(clientId: String, clientSecret: String, scopes: [String], accountId: String? = nil, isOpenIDConnect: Bool = false) {
         super.init(base: "",
@@ -60,7 +60,7 @@ open class GoogleConfig: Config {
     :param: clientId OAuth2 credentials an unique string that is generated in the OAuth2 provider Developers Console.
     :param: scopes an array of scopes the app is asking access to.
     :param: accountId this unique id is used by AccountManager to identify the OAuth2 client.
-    :paream: isOpenIDConnect to identify if fetching id information is required.
+    :param: isOpenIDConnect to identify if fetching id information is required.
     */
     public init(clientId: String, scopes: [String], accountId: String? = nil, isOpenIDConnect: Bool = false) {
         let bundleString = Bundle.main.bundleIdentifier ?? "google"
@@ -88,9 +88,9 @@ open class KeycloakConfig: Config {
     /**
     Init a Keycloak configuration.
     :param: clientId OAuth2 credentials an unique string that is generated in the OAuth2 provider Developers Console.
-    :param: host to identify where is the keycloak server located.
-    :param: realm to identify which realm to use. A realm grup a set of application/oauth2 client together.
-    :paream: isOpenIDConnect to identify if fetching id information is required.
+    :param: host to identify where the Keycloak server located.
+    :param: realm to identify which realm to use. A realm group a set of application/OAuth2 client together.
+    :param: isOpenIDConnect to identify if fetching id information is required.
     */
     public init(clientId: String, host: String, realm: String? = nil, isOpenIDConnect: Bool = false) {
         let bundleString = Bundle.main.bundleIdentifier ?? "keycloak"
@@ -209,7 +209,7 @@ open class AccountManager {
     }
 
     /**
-    Convenient method to retrieve a Facebook oauth2 module.
+    Convenient method to retrieve a Facebook OAuth2 module.
 
     :param: config a Facebook configuration object. See FacebookConfig.
 
@@ -220,7 +220,7 @@ open class AccountManager {
     }
 
     /**
-    Convenient method to retrieve a Google oauth2 module ready to be used.
+    Convenient method to retrieve a Google OAuth2 module ready to be used.
 
     :param: config a google configuration object. See GoogleConfig.
 
@@ -231,7 +231,7 @@ open class AccountManager {
     }
 
     /**
-    Convenient method to retrieve a Keycloak oauth2 module ready to be used.
+    Convenient method to retrieve a Keycloak OAuth2 module ready to be used.
 
     :param: config a Keycloak configuration object. See KeycloakConfig.
 

--- a/AeroGearOAuth2/OAuth2Module.swift
+++ b/AeroGearOAuth2/OAuth2Module.swift
@@ -73,7 +73,7 @@ open class OAuth2Module: AuthzModule {
             config.accountId = "ACCOUNT_FOR_CLIENTID_\(config.clientId)"
         }
         if (session == nil) {
-            self.oauth2Session = TrustedPersistantOAuth2Session(accountId: config.accountId!)
+            self.oauth2Session = TrustedPersistentOAuth2Session(accountId: config.accountId!)
         } else {
             self.oauth2Session = session!
         }
@@ -86,7 +86,7 @@ open class OAuth2Module: AuthzModule {
         self.state = .authorizationStateUnknown
     }
 
-    // MARK: Public API - To be overriden if necessary by OAuth2 specific adapter
+    // MARK: Public API - To be overridden if necessary by OAuth2 specific adapter
 
     /**
     Request an authorization code.

--- a/AeroGearOAuth2/OAuth2Session.swift
+++ b/AeroGearOAuth2/OAuth2Session.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /**
-The protocol that an OAuth2 Session modules must adhere to and represent storage of oauth specific metadata. See TrustedPersistantOAuth2Session and UntrustedMemoryOAuth2Session as example implementations
+The protocol that an OAuth2 Session modules must adhere to and represent storage of OAuth2 specific metadata. See TrustedPersistentOAuth2Session and UntrustedMemoryOAuth2Session as example implementations
 */
 public protocol OAuth2Session {
 
@@ -68,7 +68,7 @@ public protocol OAuth2Session {
     func clearTokens()
 
     /**
-    Save tokens information. Saving tokens allow you to refresh accesstoken transparently for the user without prompting
+    Save tokens information. Saving tokens allow you to refresh accessToken transparently for the user without prompting
     for grant access.
 
     :param: accessToken the access token.

--- a/AeroGearOAuth2/OAuth2WebViewController.swift
+++ b/AeroGearOAuth2/OAuth2WebViewController.swift
@@ -25,7 +25,7 @@ rather than an external browser approach.
 open class OAuth2WebViewController: UIViewController, UIWebViewDelegate {
     /// Login URL for OAuth.
     var targetURL: URL!
-    /// WebView intance used to load login page.
+    /// WebView instance used to load login page.
     var webView: UIWebView = UIWebView()
 
     /// Override of viewDidLoad to load the login page.

--- a/AeroGearOAuth2/TrustedPersistantOAuth2Session.swift
+++ b/AeroGearOAuth2/TrustedPersistantOAuth2Session.swift
@@ -46,19 +46,19 @@ public class KeychainWrap {
     public var serviceIdentifier: String
 
     /**
-    The group id is Keychain access group which is used for sharing keychain content accross multiple apps issued from same developer. By default there is no access group.
+    The group id is Keychain access group which is used for sharing keychain content across multiple apps issued from same developer. By default there is no access group.
     */
     public var groupId: String?
 
     /**
     Initialize KeychainWrapper setting default values.
 
-    :param: serviceId unique service, defulated to bundleId
+    :param: serviceId unique service, defaulted to bundleId
     :param: groupId used for SSO between app issued from same developer certificate.
     */
     public init(serviceId: String? =  Bundle.main.bundleIdentifier, groupId: String? = nil) {
         if serviceId == nil {
-            self.serviceIdentifier = "unkown"
+            self.serviceIdentifier = "unknown"
         } else {
             self.serviceIdentifier = serviceId!
         }
@@ -68,7 +68,7 @@ public class KeychainWrap {
     /**
     Save tokens information in Keychain.
 
-    :param: key usually use accountId for oauth2 module, any unique string.
+    :param: key usually use accountId for OAuth2 module, any unique string.
     :param: tokenType type of token: access, refresh.
     :param: value string value of the token.
     */
@@ -205,7 +205,7 @@ public class KeychainWrap {
 /**
 An OAuth2Session implementation to store OAuth2 metadata using the Keychain.
 */
-public class TrustedPersistantOAuth2Session: OAuth2Session {
+public class TrustedPersistentOAuth2Session: OAuth2Session {
 
     /**
     The account id.
@@ -345,14 +345,14 @@ public class TrustedPersistantOAuth2Session: OAuth2Session {
     }
 
     /**
-    Initialize TrustedPersistantOAuth2Session using account id. Account id is the service id used for keychain storage.
+    Initialize TrustedPersistentOAuth2Session using account id. Account id is the service id used for keychain storage.
 
-    :param: accountId uniqueId to identify the oauth2module
+    :param: accountId uniqueId to identify the OAuth2Module
     :param: groupId used for SSO between app issued from same developer certificate.
-    :param: accessToken optional parameter to initilaize the storage with initial values
-    :param: accessTokenExpirationDate optional parameter to initilaize the storage with initial values
-    :param: refreshToken optional parameter to initilaize the storage with initial values
-    :param: refreshTokenExpirationDate optional parameter to initilaize the storage with initial values
+    :param: accessToken optional parameter to initialize the storage with initial values
+    :param: accessTokenExpirationDate optional parameter to initialize the storage with initial values
+    :param: refreshToken optional parameter to initialize the storage with initial values
+    :param: refreshTokenExpirationDate optional parameter to initialize the storage with initial values
     */
     public init(accountId: String,
         groupId: String? = nil,

--- a/AeroGearOAuth2/UntrustedMemoryOAuth2Session.swift
+++ b/AeroGearOAuth2/UntrustedMemoryOAuth2Session.swift
@@ -72,7 +72,7 @@ open class UntrustedMemoryOAuth2Session: OAuth2Session {
     }
 
     /**
-    Save in memory tokens information. Saving tokens allow you to refresh accesstoken transparently for the user without prompting for grant access.
+    Save in memory tokens information. Saving tokens allow you to refresh accessToken transparently for the user without prompting for grant access.
     */
     open func save(accessToken: String?, refreshToken: String?, accessTokenExpiration: String?, refreshTokenExpiration: String?, idToken: String?) {
         self.accessToken = accessToken
@@ -99,11 +99,11 @@ open class UntrustedMemoryOAuth2Session: OAuth2Session {
     /**
     Initialize session using account id.
 
-    :param: accountId uniqueId to identify the oauth2module.
-    :param: accessToken optional parameter to initilaize the storage with initial values.
-    :param: accessTokenExpirationDate optional parameter to initilaize the storage with initial values.
-    :param: refreshToken optional parameter to initilaize the storage with initial values.
-    :param: refreshTokenExpirationDate optional parameter to initilaize the storage with initial values.
+    :param: accountId uniqueId to identify the OAuth2Module.
+    :param: accessToken optional parameter to initialize the storage with initial values.
+    :param: accessTokenExpirationDate optional parameter to initialize the storage with initial values.
+    :param: refreshToken optional parameter to initialize the storage with initial values.
+    :param: refreshTokenExpirationDate optional parameter to initialize the storage with initial values.
     */
     public init(accountId: String, accessToken: String? = nil, accessTokenExpirationDate: Date? = nil, refreshToken: String? = nil, refreshTokenExpirationDate: Date? = nil) {
         self.accessToken = accessToken

--- a/AeroGearOAuth2Tests/ConfigTest.swift
+++ b/AeroGearOAuth2Tests/ConfigTest.swift
@@ -66,7 +66,7 @@ class ConfigTests: XCTestCase {
             scopes:["photo_upload, publish_actions"],
             isOpenIDConnect: true)
         print(facebookConfig.scopes)
-        XCTAssert(facebookConfig.scopes[0] == "photo_upload, publish_actions, public_profile", "public_profile defined for Open ID Connect config, facebook does not use openid")
+        XCTAssert(facebookConfig.scopes[0] == "photo_upload, publish_actions, public_profile", "public_profile defined for Open ID Connect config, Facebook does not use openid")
 
     }
 

--- a/AeroGearOAuth2Tests/OpenIDConnectFacebookOAuth2ModuleTest.swift
+++ b/AeroGearOAuth2Tests/OpenIDConnectFacebookOAuth2ModuleTest.swift
@@ -93,7 +93,7 @@ class OpenIDConnectFacebookOAuth2ModuleTests: XCTestCase {
         oauth2Module.login {(accessToken: AnyObject?, claims: OpenIdClaim?, error: NSError?) in
             var erroDict = (error?.userInfo)!
             let value = erroDict["OpenID Connect"] as! String
-            XCTAssertTrue( value == "No UserInfo endpoint available in config", "claim shoud be as mocked")
+            XCTAssertTrue( value == "No UserInfo endpoint available in config", "claim should be as mocked")
             loginExpectation.fulfill()
 
         }

--- a/AeroGearOAuth2Tests/OpenIDConnectGoogleOAuth2ModuleTest.swift
+++ b/AeroGearOAuth2Tests/OpenIDConnectGoogleOAuth2ModuleTest.swift
@@ -61,7 +61,7 @@ class OpenIDConnectGoogleOAuth2ModuleTests: XCTestCase {
 
         oauth2Module.login {(accessToken: AnyObject?, claims: OpenIdClaim?, error: NSError?) in
 
-            XCTAssertTrue("John" == claims?.name, "claim shoud be as mocked")
+            XCTAssertTrue("John" == claims?.name, "claim should be as mocked")
             loginExpectation.fulfill()
 
         }
@@ -89,7 +89,7 @@ class OpenIDConnectGoogleOAuth2ModuleTests: XCTestCase {
         oauth2Module.login {(accessToken: AnyObject?, claims: OpenIdClaim?, error: NSError?) in
             var erroDict = (error?.userInfo)!
             let value = erroDict["OpenID Connect"] as! String
-            XCTAssertTrue( value == "No UserInfo endpoint available in config", "claim shoud be as mocked")
+            XCTAssertTrue( value == "No UserInfo endpoint available in config", "claim should be as mocked")
             loginExpectation.fulfill()
 
         }

--- a/AeroGearOAuth2Tests/OpenIDConnectKeycloakOAuth2ModuleTest.swift
+++ b/AeroGearOAuth2Tests/OpenIDConnectKeycloakOAuth2ModuleTest.swift
@@ -59,10 +59,10 @@ class OpenIDConnectKeycloakOAuth2ModuleTests: XCTestCase {
         let oauth2Module = AccountManager.addAccountWith(config: keycloakConfig, moduleClass: MyKeycloakMockOAuth2ModuleSuccess.self)
         // no need of http stub as Keycloak does not provide a UserInfo endpoint but decode JWT token
         oauth2Module.login {(accessToken: AnyObject?, claims: OpenIdClaim?, error: NSError?) in
-            XCTAssertTrue("Sample User" == claims?.name, "name claim shoud be as defined in JWT token")
-            XCTAssertTrue("User" == claims?.familyName, "family name claim shoud be as defined in JWT token")
-            XCTAssertTrue("sample-user@example" == claims?.email, "email claim shoud be as defined in JWT token")
-            XCTAssertTrue("Sample" == claims?.givenName, "given name claim shoud be as defined in JWT token")
+            XCTAssertTrue("Sample User" == claims?.name, "name claim should be as defined in JWT token")
+            XCTAssertTrue("User" == claims?.familyName, "family name claim should be as defined in JWT token")
+            XCTAssertTrue("sample-user@example" == claims?.email, "email claim should be as defined in JWT token")
+            XCTAssertTrue("Sample" == claims?.givenName, "given name claim should be as defined in JWT token")
             loginExpectation.fulfill()
 
         }


### PR DESCRIPTION
Mostly minor errors, but the big one is `TrustedPersistantOAuth2Session` --> `TrustedPersistentOAuth2Session`.