### PR TITLE
AGIOS-531: Allow use of SFSafariViewController

### DIFF
--- a/AeroGearOAuth2/Config.swift
+++ b/AeroGearOAuth2/Config.swift
@@ -111,7 +111,7 @@ open class Config {
     /**
     A handler to allow the webview to be pushed onto the navigation controller
     */
-    open var webViewHandler: ((OAuth2WebViewController, _ completionHandler: (AnyObject?, NSError?) -> Void) -> ()) = {
+    open var webViewHandler: ((UIViewController, _ completionHandler: (AnyObject?, NSError?) -> Void) -> ()) = {
         (webView, completionHandler) in
         UIApplication.shared.keyWindow?.rootViewController?.present(webView, animated: true, completion: nil)
     }

--- a/AeroGearOAuth2/Config.swift
+++ b/AeroGearOAuth2/Config.swift
@@ -103,10 +103,18 @@ open class Config {
     open var accountId: String?
 
     /**
-    Boolean to indicate to either used a webview (if true) or an external browser (by default, false)
-    for authorization code grant flow.
+    Enum to denote what kind of webView to use.
     */
-    open var isWebView: Bool = false
+    public enum WebViewType {
+        case embeddedWebView
+        case externalSafari
+        case safariViewController
+    }
+
+    /**
+    Set type of webView to use during OAuth flow.
+    */
+    open var webView: WebViewType = WebViewType.externalSafari
 
     /**
     A handler to allow the webview to be pushed onto the navigation controller
@@ -116,7 +124,7 @@ open class Config {
         UIApplication.shared.keyWindow?.rootViewController?.present(webView, animated: true, completion: nil)
     }
 
-    public init(base: String, authzEndpoint: String, redirectURL: String, accessTokenEndpoint: String, clientId: String, audienceId: String? = nil, refreshTokenEndpoint: String? = nil, revokeTokenEndpoint: String? = nil, isOpenIDConnect: Bool = false, userInfoEndpoint: String? = nil, scopes: [String] = [],  clientSecret: String? = nil, accountId: String? = nil, isWebView: Bool = false) {
+    public init(base: String, authzEndpoint: String, redirectURL: String, accessTokenEndpoint: String, clientId: String, audienceId: String? = nil, refreshTokenEndpoint: String? = nil, revokeTokenEndpoint: String? = nil, isOpenIDConnect: Bool = false, userInfoEndpoint: String? = nil, scopes: [String] = [],  clientSecret: String? = nil, accountId: String? = nil, webView: WebViewType = WebViewType.externalSafari) {
         self.baseURL = base
         self.authzEndpoint = authzEndpoint
         self.redirectURL = redirectURL
@@ -130,6 +138,6 @@ open class Config {
         self.clientSecret = clientSecret
         self.audienceId = audienceId
         self.accountId = accountId
-        self.isWebView = isWebView
+        self.webView = webView
     }
 }

--- a/AeroGearOAuth2/OAuth2Module.swift
+++ b/AeroGearOAuth2/OAuth2Module.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import UIKit
+import SafariServices
 import AeroGearHttp
 
 /**
@@ -140,7 +141,12 @@ open class OAuth2Module: AuthzModule {
                 self.webView!.targetURL = url
                 config.webViewHandler(self.webView!, completionHandler)
             } else {
-                UIApplication.shared.openURL(url)
+                if #available(iOS 9.0, *) {
+                    let safariController = SFSafariViewController(url: url)
+                    config.webViewHandler(safariController, completionHandler)
+                } else {
+                    UIApplication.shared.openURL(url)
+                }
             }
         }
     }

--- a/AeroGearOAuth2Tests/OAuth2ModuleTest.swift
+++ b/AeroGearOAuth2Tests/OAuth2ModuleTest.swift
@@ -188,7 +188,8 @@ class OAuth2ModuleTests: XCTestCase {
             scopes:["https://www.googleapis.com/auth/drive"],
             audienceId: "xxx2.apps.googleusercontent.com"
         )
-        googleConfig.isWebView = true
+
+        googleConfig.webView = Config.WebViewType.embeddedWebView
 
         let mockedSession = MockOAuth2SessionWithRefreshToken()
         let oauth2Module = OAuth2Module(config: googleConfig, session: mockedSession)


### PR DESCRIPTION
Updates #67. From the original PR: 

This PR adds support for use of SFSafariViewController to make a better UX for developers who choose to use the external browser rather than embedded webview. 